### PR TITLE
Surface CONSUL_TOKEN in consul-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ npm install hubot-consul-brain
 ```
 
 ## Usage
-Then add `hubot-consul-brain` to the list of `external-scripts.json`
+Then add `hubot-consul-brain` to the list of `external-scripts.json`.
+
 The script expects `CONSUL_HOST` and `CONSUL_PORT` or it will just use default
 values: `127.0.0.1` and `8500`.
+
+Additionally  you can also pass in `CONSUL_TOKEN` if your consul instance uses
+ACLs.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ values: `127.0.0.1` and `8500`.
 
 Additionally  you can also pass in `CONSUL_TOKEN` if your consul instance uses
 ACLs.
+
+The following consul ACL rule will allow access only to `hubot/`.
+
+```
+key "hubot/" {
+  policy = "write"
+}
+```

--- a/consul-brain.js
+++ b/consul-brain.js
@@ -1,6 +1,9 @@
 var consul = require("consul")({
   host: process.env.CONSUL_HOST || "127.0.0.1",
-  port: process.env.CONSUL_PORT || "8500"
+  port: process.env.CONSUL_PORT || "8500",
+  defaults: {
+    token: process.env.CONSUL_TOKEN || ""
+  }
 });
 
 var prefix = "hubot:storage";

--- a/consul-brain.js
+++ b/consul-brain.js
@@ -6,7 +6,7 @@ var consul = require("consul")({
   }
 });
 
-var prefix = "hubot:storage";
+var prefix = "hubot/hubot:storage";
 
 module.exports = function(robot) {
   robot.brain.setAutoSave(false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-consul-brain",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "consul-brain.js",
   "dependencies": {
     "consul": "^0.20.0"


### PR DESCRIPTION
- Updated README.md
- Added `defaults` to surface `token` which looks for the `CONSUL_TOKEN` environment variable. Defaults to empty string.
- Bumped version in package.json
